### PR TITLE
Fix #2; improve message responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,14 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>
                 <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:templates</artifact>
+                            <excludes>
+                                <exclude>META-INF/MANIFEST.MF</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                     <relocations>
                         <relocation>
                             <pattern>com.github.sanctum.templates</pattern>

--- a/src/main/java/itzshmulik/survivelist/survivelisttrails/models/Trail.java
+++ b/src/main/java/itzshmulik/survivelist/survivelisttrails/models/Trail.java
@@ -28,13 +28,12 @@ public enum Trail implements ManagedTrail, Listener {
         public boolean addFor(Player player, boolean force) {
             synchronized (runnableTrails) {
                 final RunnableBasedTrail oldTrail = runnableTrails.get(player.getUniqueId());
-                if (force) {
-                    if (oldTrail == null) return false;
+                if (force && oldTrail != null) {
                     oldTrail.cancel();
                 }
                 runnableTrails.put(player.getUniqueId(), new RunnableBasedTrail(particle, player).start());
+                return oldTrail == null || !force;
             }
-            return true;
         }
 
         @Override
@@ -56,13 +55,12 @@ public enum Trail implements ManagedTrail, Listener {
         public boolean addFor(Player player, boolean force) {
             synchronized (runnableTrails) {
                 final RunnableBasedTrail oldTrail = runnableTrails.get(player.getUniqueId());
-                if (force) {
-                    if (oldTrail == null) return false;
+                if (force && oldTrail != null) {
                     oldTrail.cancel();
                 }
                 runnableTrails.put(player.getUniqueId(), new RunnableBasedTrail(particle, player).start());
+                return oldTrail == null || !force;
             }
-            return true;
         }
 
         @Override
@@ -104,8 +102,10 @@ public enum Trail implements ManagedTrail, Listener {
             final Location to = e.getTo();
             // skip view-only movements
             if (to != null && from.toVector().equals(to.toVector())) return;
+//            System.out.println("MOVE EVENT " + e);
             // only target players in hashset
             if (!activeTrails.contains(e.getPlayer().getUniqueId())) return;
+//            System.out.println("ACTIVE TARGET " + e.getPlayer() + " Sending loc");
             // immediately send location to async calculation
             processAsync(e.getPlayer().getLocation(), particle);
         }

--- a/src/main/java/itzshmulik/survivelist/survivelisttrails/models/TrailGUI.java
+++ b/src/main/java/itzshmulik/survivelist/survivelisttrails/models/TrailGUI.java
@@ -59,9 +59,12 @@ public class TrailGUI implements Listener {
             final Player player = (Player) event.getWhoClicked();
             if (player.hasPermission("trails.totem")) {
                 //trails.startTotem
-                Trail.TOTEM.addFor(player, false);
-                // Messages can be processed async just fine
-                messageTrailEquipped(player);
+                if (Trail.TOTEM.addFor(player, true)) {
+                    // Messages can be processed async just fine
+                    messageTrailEquipped(player);
+                } else {
+                    messageTrailAlreadyEquippedReinitialize(player);
+                }
             } else {
                 messageNoPermission(player);
             }
@@ -82,8 +85,11 @@ public class TrailGUI implements Listener {
             final Player player = (Player) event.getWhoClicked();
             if (player.hasPermission("trails.fire")) {
                 //trails.startFire
-                Trail.FIRE.addFor(player, false);
-                messageTrailEquipped(player);
+                if (Trail.FIRE.addFor(player, true)) {
+                    messageTrailEquipped(player);
+                } else {
+                    messageTrailAlreadyEquippedReinitialize(player);
+                }
             } else {
                 messageNoPermission(player);
             }
@@ -102,7 +108,11 @@ public class TrailGUI implements Listener {
             final Player player = (Player) event.getWhoClicked();
             if (player.hasPermission("trails.snowball")) {
                 //particle.setID(1)
-                messageTrailEquipped(player);
+                if (Trail.CHRISTMAS_2021.addFor(player, false)) {
+                    messageTrailEquipped(player);
+                } else {
+                    messageTrailAlreadyEquipped(player);
+                }
             } else {
                 messageNoPermission(player);
             }
@@ -131,9 +141,9 @@ public class TrailGUI implements Listener {
                 }
             }
             if (multipleEnded) {
-                sendMessageAsync(player, "&c[Survivelist Trails] Removed your trails!");
+                sendMessageAsync(player, "&c&l[Survivelist Trails] &cRemoved your trails!");
             } else if (ended) {
-                sendMessageAsync(player, "&c[Survivelist Trails] Removed your trail!");
+                sendMessageAsync(player, "&c&l[Survivelist Trails] &cRemoved your trail!");
             }
             Bukkit.getScheduler().runTask(javaPlugin, player::closeInventory);
         }
@@ -145,6 +155,14 @@ public class TrailGUI implements Listener {
 
     void messageTrailEquipped(Player player) {
         sendMessageAsync(player, "&a&l[Survivelist Trails] Trail equipped!");
+    }
+
+    void messageTrailAlreadyEquipped(Player player) {
+        sendMessageAsync(player, "&a&l[Survivelist Trails] &cThis trail is already equipped.");
+    }
+
+    void messageTrailAlreadyEquippedReinitialize(Player player) {
+        sendMessageAsync(player, "&a&l[Survivelist Trails] &cThis trail is already equipped; reinitializing.");
     }
 
     void messageNoPermission(Player player) {


### PR DESCRIPTION
* Call Trail.CHRISTMAS_2021#addFor(player, false); simple return only indicates prior state
* Use boolean return of addFor + force param to trigger+indicate reinitialization
* Fix bugged addFor implementations of Trail.TOTEM and Trail.FIRE
* Add/edit messages
* Add filter step to shade to exclude Template's manifest file and remove (basically cosmetic) warning
* Write+comment out debug lines for move event listener checking (no problems! helped me check)